### PR TITLE
Add support for videos with playlist in their url

### DIFF
--- a/youtube_dl/extractor/pietsmiet.py
+++ b/youtube_dl/extractor/pietsmiet.py
@@ -16,7 +16,7 @@ from ..utils import (
 
 
 class PietsmietIE(OnceIE):
-    _VALID_URL = r'https?://(?:www\.)?pietsmiet\.de/gallery/categories/[\w-]+/(?P<id>\d+)-.*/?'
+    _VALID_URL = r'https?://(?:www\.)?pietsmiet\.de/gallery/(categories|playlists)/[\w-]+/(?P<id>\d+)-.*/?'
     _TEST = {
         'url': 'http://www.pietsmiet.de/gallery/categories/8-frag-pietsmiet/29844-fps-912',
         'info_dict': {


### PR DESCRIPTION
### Add support for videos with playlist in their url

Videos in Playlists have a specific url (e.g. https://www.pietsmiet.de/gallery/playlists/1862-pietsmiet-animated/36559-psanimated-1) which includes the keyword "playlists" instead of "categories".
This PR let the extractor accept both url keywords.